### PR TITLE
fix: replace user.Current() with os.Getenv("USER")

### DIFF
--- a/pkg/xcontext/context.go
+++ b/pkg/xcontext/context.go
@@ -239,7 +239,8 @@ var (
 
 func init() {
 	hostname, _ = os.Hostname()
-	curUser, _ = user.Current()
+	curUser = &user.User{}
+	curUser.Name = os.Getenv("USER")
 }
 
 // Extend converts a standard context to an extended one


### PR DESCRIPTION
This commit replaces user.Current() with os.Getenv("USER") as the user.Current() call provokes a crash due to a bug in glibc (especially) on older versions / OS.